### PR TITLE
Create colorRetest option and polish translations for retestStatus

### DIFF
--- a/backend/src/lib/report-generator.js
+++ b/backend/src/lib/report-generator.js
@@ -307,6 +307,16 @@ async function prepAuditData(data, settings) {
     var cellHighColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+highColor+'"/></w:tcPr>';
     var cellCriticalColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+criticalColor+'"/></w:tcPr>';
 
+    var okColor = settings.report.public.retestColors.okColor.replace('#', '');
+    var koColor = settings.report.public.retestColors.koColor.replace('#', '');
+    var unknownColor = settings.report.public.retestColors.unknownColor.replace('#', '');
+    var partialColor = settings.report.public.retestColors.partialColor.replace('#', '');
+
+    var cellOkColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="' + okColor + '"/></w:tcPr>';
+    var cellKoColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+koColor+'"/></w:tcPr>';
+    var cellUnknownColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+unknownColor+'"/></w:tcPr>';
+    var cellPartialColor = '<w:tcPr><w:shd w:val="clear" w:color="auto" w:fill="'+partialColor+'"/></w:tcPr>';
+
     var result = {}
     result.name = data.name || "undefined"
     result.auditType = $t(data.auditType) || "undefined"
@@ -424,6 +434,12 @@ async function prepAuditData(data, settings) {
         else tmpFinding.cvss.environmentalCellColor = cellNoneColor
 
         tmpFinding.cvssObj = cvssStrToObject(tmpCVSS.vectorString)
+
+        if (tmpFinding.retestStatus === "ok") tmpFinding.retestColor = cellOkColor
+        else if (tmpFinding.retestStatus === "ko") tmpFinding.retestColor = cellKoColor
+        else if (tmpFinding.retestStatus === "unknown") tmpFinding.retestColor = cellUnknownColor
+        else if (tmpFinding.retestStatus === "partial") tmpFinding.retestColor = cellPartialColor
+        else tmpFinding.cvss.cellColor = cellNoneColor
 
         if (finding.customFields) {
             for (field of finding.customFields) {

--- a/backend/src/models/settings.js
+++ b/backend/src/models/settings.js
@@ -17,6 +17,12 @@ const SettingSchema = new Schema({
                 highColor: { type: String, default: "#fe0000", validate: [colorValidator, 'Invalid color'] },
                 criticalColor: { type: String, default: "#212121", validate: [colorValidator, 'Invalid color'] }
             },
+            retestColors: {
+                okColor: { type: String, default: "#009900", validate: [colorValidator, 'Invalid color'] },
+                koColor: { type: String, default: "#ff0000", validate: [colorValidator, 'Invalid color'] },
+                unknownColor: { type: String, default: "#bfbfbf", validate: [colorValidator, 'Invalid color'] },
+                partialColor: { type: String, default: "#ffff00", validate: [colorValidator, 'Invalid color'] },
+            },
             captions: {
                 type: [{type: String, unique: true}],
                 default: ['Figure']

--- a/backend/src/translate/pl.json
+++ b/backend/src/translate/pl.json
@@ -24,6 +24,11 @@
     "Critical_S": "Krytyczne",
     "_S": "Brak",
 
+    "Retest_ok": "Usunięto",
+    "Retest_ko": "Nie usunięto",
+    "Retest_partial": "Częściowo usunięto",
+    "Retest_unknown": "Nie można ustalić",
+
     "Network_AV": "Przez sieć",
     "Adjacent Network_AV": "Przez sieć przylegającą",
     "Local_AV": "Przez dostęp lokalny",


### PR DESCRIPTION
Retest fields in template can now be colored:
`{@retestColor}`

Polish translations can be accessed as follows:
`{‘Retest_’ + retestStatus | translate: ‘pl’}`